### PR TITLE
pyobjc-framework-coreservices 8.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-    c3i_test2: pyobjc_dev
+#channels:
+#    c3i_test2: pyobjc_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
     - patches/0001-Remove-werror-from-compile-flags.patch
 
 build:
+  number: 0
   skip: True  # [not osx]
   skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Changelog: https://github.com/ronaldoussoren/pyobjc/blob/v8.5/docs/changelog.rst and https://github.com/ronaldoussoren/pyobjc/releases
Requirements: https://github.com/ronaldoussoren/pyobjc/blob/v8.5/pyobjc-framework-FSEvents/setup.py

Actions:
1. Skip py<36
2. Add patch
3. Add setuptools and wheel

NOTE: Remove abs.yaml before merging