### PR TITLE
pyobjc-framework-coreservices 9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-    c3i_test2: pyobjc_dev
+#channels:
+#    c3i_test2: pyobjc_dev

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    c3i_test2: pyobjc_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   skip: True  # [not osx]
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,20 @@ source:
     - patches/0001-Remove-werror-from-compile-flags.patch
 
 build:
-  skip: true   # [not osx]
+  skip: True  # [not osx]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - patch  # [osx]
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - pyobjc-core >={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
     - patches/0001-Remove-werror-from-compile-flags.patch
 
 build:
+  number: 0
   skip: True  # [not osx]
   skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
**Jira ticket:** []() (-)

**The upstream data:**
Repo: https://github.com/ronaldoussoren/pyobjc/tree/v9.0/pyobjc-framework-CoreServices
License: https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-CoreServices/License.txt
Requirements: 
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-CoreServices/pyobjc_setup.py
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-CoreServices/setup.py

**_Actions:_**

1. Skip `py<37`

**Package's statistics**
<details>

 * Priority  | effort:  | Category:  | subcategory:  | pkg_type: 
 * Outdated platfroms: 
 * Latest version: 
 * Release on PyPi:
    * version: 9.0
    * date: 2022-11-05T19:35:34
* [PyPi history](https://pypi.org/project/pyobjc-framework-coreservices/#history)
 * Popularity: 
    * 3 months downloads: 
    * All time:  18427 downloads -  pyobjc-framework-coreservices  9.0  Wrappers for the “CoreServices” framework on macOS.  copy  

</details>

**Other checks:**

<details>

2. - [x] https://github.com/ronaldoussoren/pyobjc is present
3. - [x] Check the pinnings
5. - [x] Additional research
    https://github.com/ronaldoussoren/pyobjc/issues
    200
6. - [x] `dev_url` is present
    https://github.com/ronaldoussoren/pyobjc
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: License.txt is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

17. - [x] license_family MIT is present
</details>