### PR TITLE
PKG-1277: Updates for v9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-   c3i_test2: pyobjc_dev_sdk10.15
+# channels:
+#    c3i_test2: pyobjc_dev_sdk10.15

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-# channels:
-#    c3i_test2: pyobjc_dev_sdk10.15
+channels:
+   c3i_test2: pyobjc_dev_sdk10.15

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+   c3i_test2: pyobjc_dev_sdk10.15

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,12 @@
+macos_min_version:
+  - 10.15  # [osx and x86_64]
+  - 11.13  # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15  # [osx and x86_64]
+  - 11.3  # [osx and arm64]
+MACOSX_SDK_VERSION:        # [osx]
+  - "10.15"                # [osx and x86_64]
+  - "11.3"                 # [osx and arm64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyobjc-framework-CoreServices" %}
-{% set version = "8.5" %}
+{% set version = "9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +7,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 58bad844c8e5ee82852d860b117d1238c3ed2db8dd57f754feb6bd5801fe878d
+  sha256: 476d6d4aa3afa7706f09dc9b9c8ec22c724953d123bed4d2c419db825cd1d66b
   patches:
     - patches/0001-Remove-werror-from-compile-flags.patch
 
 build:
-  skip: true   # [not osx]
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 0
+  skip: True  # [not osx]
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - python
+    - patch  # [osx]
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - pyobjc-core >={{ version }}
@@ -32,7 +35,7 @@ requirements:
 test:
   imports:
     - CoreServices
-    - CoreServices.CarbonCore
+    - CoreServices.CarbonCore`
     - CoreServices.DictionaryServices
     - CoreServices.LaunchServices
     - CoreServices.Metadata
@@ -44,7 +47,7 @@ test:
 
 about:
   home: https://github.com/ronaldoussoren/pyobjc
-  summary: 'Wrappers for the “CoreServices” framework on macOS.'
+  summary: Wrappers for the “CoreServices” framework on macOS.
   description: |
     The PyObjC project aims to provide a bridge between the Python and
     Objective-C programming languages on macOS. The bridge is intended to be

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 test:
   imports:
     - CoreServices
-    - CoreServices.CarbonCore`
+    - CoreServices.CarbonCore
     - CoreServices.DictionaryServices
     - CoreServices.LaunchServices
     - CoreServices.Metadata


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-1277

Needed to use latest `python-3.10.9` with the latest `spyder-5.4.1` (which depends on `pyobjc-framework-cocoa` as a sub-dependency.

Successful dev builds in the `c3i_test2` channel: https://anaconda.org/c3i_test2/pyobjc-framework-coreservices/files?channel=pyobjc_dev_sdk10.15